### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/Musical-Neutron/MW_Satellite_LF/security/code-scanning/1](https://github.com/Musical-Neutron/MW_Satellite_LF/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/test_package.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
Best minimal fix without changing behavior is:

- `contents: read` (required for `actions/checkout`)
- `actions: read` (safe/read-only for workflow metadata usage; optional but explicit)

For this workflow, no write permissions are required. `actions/upload-artifact` does not require broad repo write scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
