### PR TITLE
Fixing typo in Publication Year

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -58,5 +58,5 @@ preferred-citation:
       description: Journal article concerning this repository
   title: 'The total satellite population of the Milky Way'
   journal: 'Monthly Notices of the Royal Astronomical Society'
-  year: 2028
+  year: 2018
   type: article


### PR DESCRIPTION
# Description

The CITATION file erroneously listed the publication year as 2028 instead of 2018. This PR fixes that issue.

## Type of change

- [x] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
